### PR TITLE
fix: avoid division by zero when calculating statistics

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime/pprof"
@@ -336,10 +337,10 @@ func run() error {
 			Errors:             errors,
 			DirEntries:         dirEntries,
 			FilesOpened:        filesOpened,
-			FilesOpenedPercent: 100 * float64(filesOpened) / float64(dirEntries),
+			FilesOpenedPercent: 100 * float64(filesOpened) / math.Max(1, float64(dirEntries)),
 			TotalBytes:         totalBytes,
 			BytesHashed:        bytesHashed,
-			BytesHashedPercent: 100 * float64(bytesHashed) / float64(totalBytes),
+			BytesHashedPercent: 100 * float64(bytesHashed) / math.Max(1, float64(totalBytes)),
 		}); err != nil {
 			return err
 		}


### PR DESCRIPTION
This commit fixes an edge case where an empty directory is provided. In that case, `dirEntries` and `totalBytes` will be zero.

**How to reproduce:**

```
$ mkdir emptydir
$ find-duplicates --statistics ./emptydir
{}
json: unsupported value: NaN
```